### PR TITLE
Order : #59 주문 생성에서 발생한 버그 수정

### DIFF
--- a/order/src/main/java/com/keepgoing/order/application/service/order/OrderScheduler.java
+++ b/order/src/main/java/com/keepgoing/order/application/service/order/OrderScheduler.java
@@ -22,7 +22,6 @@ public class OrderScheduler {
     private static final Set<OrderState> PROCESSING_STATES = Set.of(
         OrderState.PENDING_VALIDATION,
         OrderState.PRODUCT_VERIFIED,
-        OrderState.AWAITING_PAYMENT,
         OrderState.PAID
     );
 


### PR DESCRIPTION
### 기존 문제점
- 주문에서 재고 예약 후, `AWAITING_PAYMENT` 상태로 전이되는데, 이후 스케줄러에 의해서 바로 `PAID` 상태로 전이되는 문제가 발생 
- 결제 서비스에서 결제를 진행한 후, `PAID` 상태로 전이되면 다음 작업을 수행하도록 해야함 
<img width="1182" height="1598" alt="image" src="https://github.com/user-attachments/assets/0be12c46-aa21-4823-ab4c-f39b9101a7f0" />

### 변경된 부분
- `OrderProcessor`에서 `AWAITING_PAYMENT` 상태일 때 실행되는 코드 부분 제거 

### 전체 처리 과정
<img width="1564" height="1649" alt="image" src="https://github.com/user-attachments/assets/174129f3-e467-4c2e-b61d-c6fa5792c2ae" />


### 추가적으로 변경된 부분 
- 주문 선점 전의 데이터를 주문 선점 후에 사용하는 문제 발견 ( 만에 하나 주문 정보가 수정되어 문제가 될 수 있음 )
- 주문 선점 이후 주문 정보를 다시 불러와 최신 데이터를 기반으로 로직이 실행되도록 수정 …어와서 작업을 수행하도록 개선