### PR TITLE
feat: #63, #62 회원 상태에 따른 로그인 flow E2E 완료

### DIFF
--- a/member/build.gradle
+++ b/member/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
+    testImplementation 'io.rest-assured:json-path:5.5.0'
 }
 
 dependencyManagement {

--- a/member/src/main/java/com/sparta/member/application/mapper/ApplicationMapper.java
+++ b/member/src/main/java/com/sparta/member/application/mapper/ApplicationMapper.java
@@ -1,9 +1,12 @@
 package com.sparta.member.application.mapper;
 
 import com.sparta.member.domain.model.Member;
+import com.sparta.member.interfaces.dto.MemberInfoResponseDto;
 import com.sparta.member.interfaces.dto.StatusUpdateResponseDto;
 
 public interface ApplicationMapper {
 
     StatusUpdateResponseDto toStatusUpdateResponseDto(Member savedMember);
+
+    MemberInfoResponseDto toGetMemberResponseDto(Member byId);
 }

--- a/member/src/main/java/com/sparta/member/application/mapper/MemberMapper.java
+++ b/member/src/main/java/com/sparta/member/application/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.sparta.member.application.mapper;
 
 import com.sparta.member.domain.model.Member;
+import com.sparta.member.interfaces.dto.MemberInfoResponseDto;
 import com.sparta.member.interfaces.dto.StatusUpdateResponseDto;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,20 @@ public class MemberMapper implements ApplicationMapper {
             savedMember.accountInfo().email(),
             savedMember.accountInfo().name(),
             savedMember.status()
+        );
+    }
+
+    @Override
+    public MemberInfoResponseDto toGetMemberResponseDto(Member member) {
+        return new MemberInfoResponseDto(
+            member.accountInfo().name(),
+            member.accountInfo().email(),
+            member.accountInfo().slackId(),
+            member.affiliation().type(),
+            member.affiliation().name(),
+            member.affiliation().id(),
+            member.role(),
+            member.status()
         );
     }
 }

--- a/member/src/main/java/com/sparta/member/application/service/MemberService.java
+++ b/member/src/main/java/com/sparta/member/application/service/MemberService.java
@@ -2,6 +2,7 @@ package com.sparta.member.application.service;
 
 import com.sparta.member.domain.enums.Status;
 import com.sparta.member.domain.vo.Affiliation;
+import com.sparta.member.interfaces.dto.MemberInfoResponseDto;
 import com.sparta.member.interfaces.dto.SignUpRequestDto;
 import com.sparta.member.application.mapper.ApplicationMapper;
 import com.sparta.member.domain.model.Member;
@@ -42,7 +43,7 @@ public class MemberService {
         return savedMember.id();
     }
 
-    public StatusUpdateResponseDto updateStatus(StatusChangeRequestDto requestDto) {
+    public StatusUpdateResponseDto updateStatus(StatusChangeRequestDto requestDto, Long id) {
         Member targetMember = memberRepository.findByEmail(requestDto.email());
         switch(requestDto.status()) {
             case APPROVED -> targetMember.approve();
@@ -50,5 +51,9 @@ public class MemberService {
         }
         Member savedMember = memberRepository.save(targetMember);
         return mapper.toStatusUpdateResponseDto(savedMember);
+    }
+
+    public MemberInfoResponseDto getMemberInfo(Long id) {
+        return mapper.toGetMemberResponseDto(memberRepository.findById(id));
     }
 }

--- a/member/src/main/java/com/sparta/member/domain/model/Member.java
+++ b/member/src/main/java/com/sparta/member/domain/model/Member.java
@@ -28,6 +28,7 @@ public class Member {
         String slackId,
         Affiliation affiliation,
         Role role,
+        Status status,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime deletedAt,
@@ -42,7 +43,7 @@ public class Member {
         );
         this.affiliation = affiliation;
         this.role = role;
-        this.status = Status.PENDING;
+        this.status = status == null ? Status.PENDING :  status;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
@@ -65,7 +66,7 @@ public class Member {
             "affiliation", affiliation,
             "role", role
         );
-        return new Member(null, name, password, email, slackId, affiliation, role, LocalDateTime.now(), LocalDateTime.now(), null, null);
+        return new Member(null, name, password, email, slackId, affiliation, role, null,LocalDateTime.now(), LocalDateTime.now(), null, null);
     }
 
     public void approve() {
@@ -127,6 +128,7 @@ public class Member {
         String slackId,
         Affiliation affiliation,
         Role role,
+        Status status,
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         LocalDateTime deletedAt,
@@ -144,6 +146,6 @@ public class Member {
             "updatedAt", updatedAt
         );
 
-        return new Member(id, name, password, email, slackId, affiliation, role, createdAt, updatedAt, deletedAt, deleteBy);
+        return new Member(id, name, password, email, slackId, affiliation, role, status, createdAt, updatedAt, deletedAt, deleteBy);
     }
 }

--- a/member/src/main/java/com/sparta/member/domain/repository/MemberRepository.java
+++ b/member/src/main/java/com/sparta/member/domain/repository/MemberRepository.java
@@ -25,4 +25,6 @@ public interface MemberRepository {
     List<Member> saveAll(List<Member> members);
 
     boolean existsByEmail(String email);
+
+    Member findById(Long id);
 }

--- a/member/src/main/java/com/sparta/member/domain/vo/AccountInfo.java
+++ b/member/src/main/java/com/sparta/member/domain/vo/AccountInfo.java
@@ -10,7 +10,7 @@ public record AccountInfo(
 ) {
     public AccountInfo {
         requireAllNonNull(
-            "type", name,
+            "name", name,
             "password", password,
             "email", email,
             "slackId", slackId

--- a/member/src/main/java/com/sparta/member/infrastructure/config/DataInitializer.java
+++ b/member/src/main/java/com/sparta/member/infrastructure/config/DataInitializer.java
@@ -7,6 +7,7 @@ import com.sparta.member.domain.vo.Affiliation;
 import com.sparta.member.domain.vo.Type;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class DataInitializer {
 
     private final MemberRepository memberRepository;
@@ -25,6 +27,7 @@ public class DataInitializer {
     @Bean
     @Order(1)
     public CommandLineRunner initDatabase(MemberRepository memberRepository) {
+        log.info("init database start MASTER account");
         return args -> {
             String masterEmail = "master@master.com";
             if (memberRepository.existsByEmail(masterEmail)) {
@@ -42,6 +45,8 @@ public class DataInitializer {
                 ),
                 Role.MASTER
             );
+            master.approve();
+            log.info("init database finish MASTER account" + master.status());
             memberRepository.save(master);
         };
     }

--- a/member/src/main/java/com/sparta/member/infrastructure/persistence/jpa/MemberRepositoryImpl.java
+++ b/member/src/main/java/com/sparta/member/infrastructure/persistence/jpa/MemberRepositoryImpl.java
@@ -68,4 +68,11 @@ public class MemberRepositoryImpl implements MemberRepository {
         return memberJpaRepository.findByEmail(email).isPresent();
     }
 
+    @Override
+    public Member findById(Long id) {
+        return mapper.toMember(memberJpaRepository.findById(id)
+            .orElseThrow(() ->
+                new CustomException(ErrorCode.MEMBER_NOT_FOUND)
+            ));
+    }
 }

--- a/member/src/main/java/com/sparta/member/infrastructure/persistence/mapper/MemberJpaMapper.java
+++ b/member/src/main/java/com/sparta/member/infrastructure/persistence/mapper/MemberJpaMapper.java
@@ -28,6 +28,7 @@ public class MemberJpaMapper implements PersistenceMapper {
                 memberJpa.getAffiliationName()
             ),
             memberJpa.getRole(),
+            memberJpa.getStatus(),
             memberJpa.getCreatedAt(),
             memberJpa.getUpdatedAt(),
             memberJpa.getDeletedAt(),

--- a/member/src/main/java/com/sparta/member/infrastructure/userDetails/CustomUserDetails.java
+++ b/member/src/main/java/com/sparta/member/infrastructure/userDetails/CustomUserDetails.java
@@ -1,5 +1,6 @@
 package com.sparta.member.infrastructure.userDetails;
 
+import com.sparta.member.domain.enums.Status;
 import com.sparta.member.infrastructure.persistence.jpa.entity.MemberJpa;
 import java.util.Collection;
 import java.util.List;
@@ -48,7 +49,7 @@ public class CustomUserDetails implements UserDetails {
     // TODO: 계정의 승인 상태에 따라 false 값 반환하도록 변경
     @Override
     public boolean isEnabled() {
-        return true;
+        return member.getStatus() == Status.APPROVED;
     }
 
     @Override

--- a/member/src/main/java/com/sparta/member/interfaces/dto/MemberInfoResponseDto.java
+++ b/member/src/main/java/com/sparta/member/interfaces/dto/MemberInfoResponseDto.java
@@ -1,0 +1,18 @@
+package com.sparta.member.interfaces.dto;
+
+import com.sparta.member.domain.enums.Role;
+import com.sparta.member.domain.enums.Status;
+import com.sparta.member.domain.vo.Type;
+import java.util.UUID;
+
+public record MemberInfoResponseDto(
+    String name,
+    String email,
+    String slackId,
+    Type affiliationType,
+    String affiliationName,
+    UUID affiliationId,
+    Role Role,
+    Status status
+) {
+}

--- a/member/src/main/java/com/sparta/member/interfaces/web/MemberController.java
+++ b/member/src/main/java/com/sparta/member/interfaces/web/MemberController.java
@@ -7,6 +7,7 @@ import com.sparta.member.application.service.MemberService;
 import com.sparta.member.interfaces.dto.SignUpRequestDto;
 import com.sparta.member.interfaces.dto.StatusChangeRequestDto;
 import com.sparta.member.interfaces.dto.StatusUpdateResponseDto;
+import com.sparta.member.interfaces.dto.MemberInfoResponseDto;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -29,8 +30,18 @@ public class MemberController {
     private final MemberService memberService;
     private final AuthService authService;
 
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponseDto<MemberInfoResponseDto>> getMemberById(
+        @PathVariable Long id
+    ) {
+        MemberInfoResponseDto res = memberService.getMemberInfo(id);
+
+        return ResponseEntity.ok()
+            .body(BaseResponseDto.success(res));
+    }
+
     @PostMapping("/login")
-    public ResponseEntity<?> login(
+    public ResponseEntity<BaseResponseDto<?>> login(
         @RequestBody LoginDto loginDto
     ) {
         String token = authService.login(loginDto);
@@ -40,7 +51,7 @@ public class MemberController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(
+    public ResponseEntity<BaseResponseDto<?>> register(
         @RequestBody @Validated SignUpRequestDto requestDto
     ) {
         Long id = memberService.requestSignUp(requestDto);
@@ -53,12 +64,12 @@ public class MemberController {
 
     @PreAuthorize("hasRole('MASTER')")
     @PatchMapping("/{id}/status")
-    public ResponseEntity<?> updateStatus(
+    public ResponseEntity<BaseResponseDto<?>> updateStatus(
         @PathVariable Long id,
         @RequestBody StatusChangeRequestDto requestDto
     ) {
 
-        StatusUpdateResponseDto res = memberService.updateStatus(requestDto);
+        StatusUpdateResponseDto res = memberService.updateStatus(requestDto, id);
 
         return ResponseEntity.noContent()
             .build();

--- a/member/src/main/resources/application-test.yml
+++ b/member/src/main/resources/application-test.yml
@@ -13,6 +13,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
+    show-sql: true
   h2:
     console:
       enabled: false

--- a/member/src/test/java/com/sparta/member/E2E.java
+++ b/member/src/test/java/com/sparta/member/E2E.java
@@ -1,0 +1,124 @@
+package com.sparta.member;
+
+import static io.restassured.RestAssured.given;
+import static org.instancio.Select.field;
+
+import com.sparta.member.application.dto.LoginDto;
+import com.sparta.member.domain.enums.Role;
+import com.sparta.member.domain.enums.Status;
+import com.sparta.member.domain.model.Member;
+import com.sparta.member.domain.repository.MemberRepository;
+import com.sparta.member.domain.vo.Affiliation;
+import com.sparta.member.domain.vo.Type;
+import com.sparta.member.interfaces.dto.SignUpRequestDto;
+import com.sparta.member.interfaces.dto.StatusChangeRequestDto;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class E2E {
+
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @LocalServerPort
+    private int port;
+
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        if (!memberRepository.existsByEmail("master@master.com")) {
+            Member master = Member.requestSignUp(
+                "마스터",
+                passwordEncoder.encode("123"),
+                "master@master.com",
+                "master",
+                new Affiliation(Type.COMPANY, UUID.randomUUID(), "sparta"),
+                Role.MASTER
+            );
+            memberRepository.save(master);
+        }
+    }
+
+    @Test
+    @DisplayName("회원 생성 부터 로그인 까지")
+    void createMemberReqAndFailLogin_E2E() {
+        // given
+        var memberReq = Instancio.of(SignUpRequestDto.class)
+            .set(field(SignUpRequestDto::email), "test@test.com")
+            .set(field(SignUpRequestDto::password), "123")
+            .create();
+        var loginDto = new LoginDto("test@test.com", "123");
+        var loginMaster = new LoginDto("master@master.com", "123");
+        var statusChangeReq = new StatusChangeRequestDto(
+            "test@test.com",
+            Status.APPROVED
+        );
+
+        String masterJwt =
+            given().contentType(ContentType.JSON)
+                .body(loginMaster)
+                .when()
+                .post("/v1/member/login")
+                .then()
+                .statusCode(200)
+                .extract()
+                .header("Authorization");
+
+        // when: 회원 가입 요청 생성
+        String location =
+            given().contentType(ContentType.JSON)
+                .body(memberReq)
+                .when()
+                .post("/v1/member/register")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location");
+
+        Long newMemberId = Long.valueOf(location.substring(location.lastIndexOf('/') + 1));
+
+
+        // then
+        // PENDING 상태 로그인 실패
+        given().contentType(ContentType.JSON)
+            .body(loginDto)
+            .when()
+            .post("/v1/member/login")
+            .then()
+            .statusCode(401);
+
+
+        // MASTER 권한 사용자가 APPROVED 상태로 변경
+        given().contentType(ContentType.JSON)
+            .header("Authorization", masterJwt)
+            .body(statusChangeReq)
+            .when()
+            .patch("/v1/member/{id}/status", newMemberId)
+            .then()
+            .statusCode(204);
+
+        // 이후 로그인 성공
+        given().contentType(ContentType.JSON)
+            .body(loginDto)
+            .when()
+            .post("/v1/member/login")
+            .then()
+            .statusCode(200);
+    }
+}

--- a/member/src/test/java/com/sparta/member/fixture/MemberFixture.java
+++ b/member/src/test/java/com/sparta/member/fixture/MemberFixture.java
@@ -1,6 +1,7 @@
 package com.sparta.member.fixture;
 
 import com.sparta.member.domain.enums.Role;
+import com.sparta.member.domain.enums.Status;
 import com.sparta.member.domain.model.Member;
 import com.sparta.member.domain.vo.Affiliation;
 import com.sparta.member.domain.vo.Type;
@@ -61,6 +62,7 @@ public final class MemberFixture {
             SLACK_ID,
             affiliation(),
             ROLE,
+            null,
             LocalDateTime.now(),
             LocalDateTime.now(),
             null,


### PR DESCRIPTION
## 회원 단건 조회 API, 로그인 flow E2E 완료
- 로그인 과정에서 MASTER 계정 로그인 문제 발생으로 인하여 확인차 부득이 하게 같은 커밋에서 작성 진행하게 되었습니다

### E2E
1. 회원 가입 요청 생성(member1)
2. member1 의 로그인 시도 (실패)
3. master 계정의 approved
4. member1 의 로그인 시도 (성공)

### 회원 단건 조회
- 아직 권한에 따른 분기는 설정하지 못 하였습니다
- MVP 개발후 권한 분기 추가하도록 하겠습니다